### PR TITLE
[feat/#42] 방 생성 페이지 api 연동 및 라우팅 구현 ver2

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -18,7 +18,7 @@ export const routes = [
       { path: '/entryRoom', element: <EntryRoomPage /> },
       { path: '/drawingRoom', element: <DrawingResultPage /> },
       {
-        path: '/game',
+        path: '/game/:UUID',
         element: <GamePage />,
       },
       { path: '/result', element: <GameResultPage /> },

--- a/src/apis/axiosCustom.ts
+++ b/src/apis/axiosCustom.ts
@@ -1,0 +1,8 @@
+import axios, { AxiosInstance } from 'axios';
+
+export const customAxios: AxiosInstance = axios.create({
+  baseURL: 'http://localhost:8080/api/v1',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/src/apis/creatingSpecificRoomsAPI.ts
+++ b/src/apis/creatingSpecificRoomsAPI.ts
@@ -1,0 +1,27 @@
+import { MakeRoomType } from '@/types/creatingSpecificRooms';
+import { customAxios } from './axiosCustom';
+
+export const makeRoomAPI = async ({
+  nickname,
+  selectedCategory,
+  seconds,
+  personnel,
+}: MakeRoomType) => {
+  try {
+    const response = await customAxios.post('/rooms', {
+      nickname: nickname,
+      category_id: selectedCategory,
+      time: seconds,
+      player_num: personnel,
+    });
+    const gameInfo = {
+      nickname,
+      time: seconds,
+      player_num: personnel,
+      entry_code: response.data.uuid,
+    };
+    return gameInfo;
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/components/SkeletonUI/index.tsx
+++ b/src/components/SkeletonUI/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import LoadingGIF from '@/assets/Loading.gif';
+
+const SkeletonUI = () => {
+  return (
+    <>
+      <Loading />
+    </>
+  );
+};
+
+export default SkeletonUI;
+
+const Loading = styled.img.attrs({
+  src: `${LoadingGIF}`,
+})`
+  width: 100vw;
+  height: 100vh;
+`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,9 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { worker } from './mocks/worker';
 
-if (import.meta.env.DEV) {
-  worker.start();
-}
+// if (import.meta.env.DEV) {
+//   worker.start();
+// }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { styled } from 'styled-components';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import Teaching from '@/assets/Teaching.png';
 import FireExtinguisher from '@/assets/FireExtinguisher.png';
@@ -10,6 +9,8 @@ import Chatter from '@/assets/Chatter.png';
 import { roomElement } from '@/constants/roomElement';
 import Header from '@/common/Header';
 import Label from '@/components/Entrance/EntranceLabel';
+import { GameInfoProps } from '@/types/creatingSpecificRooms';
+import { makeRoomAPI } from '@/apis/creatingSpecificRoomsAPI';
 
 const CreatingRooms = () => {
   const navigate = useNavigate();
@@ -18,6 +19,7 @@ const CreatingRooms = () => {
   const [nickname, setNickname] = useState('');
   const [personnel, setPersonnel] = useState(2);
   const [seconds, setSeconds] = useState(10);
+
   const increasePersonnel = () => {
     if (personnel < 8) {
       setPersonnel(personnel + 1);
@@ -43,40 +45,22 @@ const CreatingRooms = () => {
     setNickname(e.target.value);
   };
 
-  type GameInfoProps = {
-    nickname: string;
-    time: number;
-    player_num: number;
-    entry_code: string;
-  };
-
-  const goToGame = (gameInfo: GameInfoProps) =>
-    navigate('/game', { state: gameInfo });
-
-  const createSpecificRoom = async () => {
-    try {
-      const response = await axios.post('http://localhost:8080/api/v1/rooms', {
-        nickname: nickname,
-        category_id: selectedCategory,
-        time: seconds,
-        player_num: personnel,
-      });
-
-      const gameInfo = {
-        nickname,
-        time: seconds,
-        player_num: personnel,
-        entry_code: response.data.uuid,
-      };
-
-      goToGame(gameInfo);
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
   const clickCategory = (categoryId: number) => {
     setSelectedCategory(categoryId);
+  };
+
+  const goToGame = (gameInfo?: GameInfoProps) =>
+    navigate(`/game/${gameInfo?.entry_code}`, { state: gameInfo });
+
+  const handleMakeRoom = async () => {
+    const data = {
+      nickname,
+      selectedCategory,
+      seconds,
+      personnel,
+    };
+    const result = await makeRoomAPI(data);
+    goToGame(result);
   };
 
   return (
@@ -146,7 +130,7 @@ const CreatingRooms = () => {
             </div>
           </div>
         </UIContainer>
-        <button className="CreatingRoomButton" onClick={createSpecificRoom}>
+        <button className="CreatingRoomButton" onClick={handleMakeRoom}>
           방 만들기
         </button>
         <ChatterImg src={Chatter} alt="떠든사람" />

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -42,13 +42,11 @@ const CreatingRooms = () => {
 
   const createSpecificRoom = async () => {
     try {
-      const response = await axios.post('/api/v1/rooms', {
-        params: {
-          nickname: nickname,
-          category_id: selectedCategory,
-          time: seconds,
-          player_num: personnel,
-        },
+      const response = await axios.post('http://localhost:8080/api/v1/rooms', {
+        nickname: nickname,
+        category_id: selectedCategory,
+        time: seconds,
+        player_num: personnel,
       });
 
       console.log(response);

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { styled } from 'styled-components';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 import Teaching from '@/assets/Teaching.png';
 import FireExtinguisher from '@/assets/FireExtinguisher.png';
 import DoodleFunctionMath from '@/assets/DoodleFunctionMath.png';
@@ -11,6 +12,8 @@ import Header from '@/common/Header';
 import Label from '@/components/Entrance/EntranceLabel';
 
 const CreatingRooms = () => {
+  const navigate = useNavigate();
+
   const [selectedCategory, setSelectedCategory] = useState(1);
   const [nickname, setNickname] = useState('');
   const [personnel, setPersonnel] = useState(2);
@@ -40,6 +43,16 @@ const CreatingRooms = () => {
     setNickname(e.target.value);
   };
 
+  type GameInfoProps = {
+    nickname: string;
+    time: number;
+    player_num: number;
+    entry_code: string;
+  };
+
+  const goToGame = (gameInfo: GameInfoProps) =>
+    navigate('/game', { state: gameInfo });
+
   const createSpecificRoom = async () => {
     try {
       const response = await axios.post('http://localhost:8080/api/v1/rooms', {
@@ -49,7 +62,14 @@ const CreatingRooms = () => {
         player_num: personnel,
       });
 
-      console.log(response);
+      const gameInfo = {
+        nickname,
+        time: seconds,
+        player_num: personnel,
+        entry_code: response.data.uuid,
+      };
+
+      goToGame(gameInfo);
     } catch (e) {
       console.error(e);
     }

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -11,6 +11,7 @@ import Header from '@/common/Header';
 import Label from '@/components/Entrance/EntranceLabel';
 
 const CreatingRooms = () => {
+  const [selectedCategory, setSelectedCategory] = useState(1);
   const [nickname, setNickname] = useState('');
   const [personnel, setPersonnel] = useState(2);
   const [seconds, setSeconds] = useState(10);
@@ -56,6 +57,10 @@ const CreatingRooms = () => {
     }
   };
 
+  const clickCategory = (categoryId: number) => {
+    setSelectedCategory(categoryId);
+  };
+
   return (
     <Admissions>
       <Header />
@@ -72,7 +77,7 @@ const CreatingRooms = () => {
         </DoodleContainer>
         <CategoryContainer>
           {roomElement.map((item, index) => (
-            <div key={index}>
+            <div key={index + 1} onClick={() => clickCategory(index + 1)}>
               <img src={item.image} alt={item.id} />
               <label>{item.id}</label>
             </div>

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -45,7 +45,7 @@ const CreatingRooms = () => {
       const response = await axios.post('/api/v1/rooms', {
         params: {
           nickname: nickname,
-          category_id: 2,
+          category_id: selectedCategory,
           time: seconds,
           player_num: personnel,
         },
@@ -77,7 +77,16 @@ const CreatingRooms = () => {
         </DoodleContainer>
         <CategoryContainer>
           {roomElement.map((item, index) => (
-            <div key={index + 1} onClick={() => clickCategory(index + 1)}>
+            <div
+              key={index + 1}
+              onClick={() => clickCategory(index + 1)}
+              style={{
+                backgroundColor:
+                  index + 1 === selectedCategory
+                    ? 'rgba(255, 255, 255, 0.18)'
+                    : '',
+              }}
+            >
               <img src={item.image} alt={item.id} />
               <label>{item.id}</label>
             </div>

--- a/src/pages/CreatingSpecificRooms/index.tsx
+++ b/src/pages/CreatingSpecificRooms/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { styled } from 'styled-components';
+import axios from 'axios';
 import Teaching from '@/assets/Teaching.png';
 import FireExtinguisher from '@/assets/FireExtinguisher.png';
 import DoodleFunctionMath from '@/assets/DoodleFunctionMath.png';
@@ -10,6 +11,7 @@ import Header from '@/common/Header';
 import Label from '@/components/Entrance/EntranceLabel';
 
 const CreatingRooms = () => {
+  const [nickname, setNickname] = useState('');
   const [personnel, setPersonnel] = useState(2);
   const [seconds, setSeconds] = useState(10);
   const increasePersonnel = () => {
@@ -32,6 +34,28 @@ const CreatingRooms = () => {
       setSeconds(seconds - 10);
     }
   };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const createSpecificRoom = async () => {
+    try {
+      const response = await axios.post('/api/v1/rooms', {
+        params: {
+          nickname: nickname,
+          category_id: 2,
+          time: seconds,
+          player_num: personnel,
+        },
+      });
+
+      console.log(response);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <Admissions>
       <Header />
@@ -71,6 +95,8 @@ const CreatingRooms = () => {
             <Label name="닉네임" />
             <NickNameInput
               placeholder="닉네임을 입력해주세요"
+              value={nickname}
+              onChange={handleNicknameChange}
               required
               maxLength={5}
             />
@@ -88,7 +114,9 @@ const CreatingRooms = () => {
             </div>
           </div>
         </UIContainer>
-        <button className="CreatingRoomButton">방 만들기</button>
+        <button className="CreatingRoomButton" onClick={createSpecificRoom}>
+          방 만들기
+        </button>
         <ChatterImg src={Chatter} alt="떠든사람" />
       </Blackboard>
     </Admissions>

--- a/src/pages/EntryRoom/index.tsx
+++ b/src/pages/EntryRoom/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { styled } from 'styled-components';
 import chattingImg from '@/assets/Chatter.png';
 import CompassImg from '@/assets/DoodleCompass.png';

--- a/src/pages/Game/index.tsx
+++ b/src/pages/Game/index.tsx
@@ -1,10 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import GameBoard from '@/components/Game/GameBoard';
 import GameNav from '@/components/Game/GameNav';
 import UsersChat from '@/components/Game/UsersChat';
 import { styled } from 'styled-components';
 import pencil from '@/assets/pencil.png';
 const Game = () => {
+  const navigate = useNavigate();
+
+  const { state } = useLocation();
+
+  useEffect(() => {
+    console.log(state);
+  }, []);
+
   const [xy, setXY] = useState({ x: 0, y: 0 });
   const [currentFocus, setCurrentFocus] = useState(pencil);
   const xyHandler = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/pages/Game/index.tsx
+++ b/src/pages/Game/index.tsx
@@ -6,13 +6,7 @@ import UsersChat from '@/components/Game/UsersChat';
 import { styled } from 'styled-components';
 import pencil from '@/assets/pencil.png';
 const Game = () => {
-  const navigate = useNavigate();
-
-  const { state } = useLocation();
-
-  useEffect(() => {
-    console.log(state);
-  }, []);
+  const { nickname, time, player_num, entry_code } = useLocation().state;
 
   const [xy, setXY] = useState({ x: 0, y: 0 });
   const [currentFocus, setCurrentFocus] = useState(pencil);

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -5,6 +5,7 @@ import BlackboardDecoInMainPage from '@/assets/BlackboardDecoInMainPage.png';
 import FireExtinguisher from '@/assets/FireExtinguisher.png';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import Loading from '@/assets/Loading.gif';
 const Main = () => {
   const navigate = useNavigate();
   const goToEntryRoom = () => navigate('/entryRoom');

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -1,10 +1,9 @@
 import React, { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
-import Loading from '@/components/SkeletonUI';
 
 export default function Layout() {
   return (
-    <Suspense fallback={<Loading />}>
+    <Suspense fallback={'...loading'}>
       <Outlet />
     </Suspense>
   );

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -1,9 +1,10 @@
 import React, { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
+import Loading from '@/components/SkeletonUI';
 
 export default function Layout() {
   return (
-    <Suspense fallback={'...loading'}>
+    <Suspense fallback={<Loading />}>
       <Outlet />
     </Suspense>
   );

--- a/src/types/creatingSpecificRooms.ts
+++ b/src/types/creatingSpecificRooms.ts
@@ -1,0 +1,13 @@
+export type GameInfoProps = {
+  nickname: string;
+  time: number;
+  player_num: number;
+  entry_code: string;
+};
+
+export type MakeRoomType = {
+  nickname: string;
+  selectedCategory: number;
+  seconds: number;
+  personnel: number;
+};


### PR DESCRIPTION
## 추가한 기능 설명
1. 방 생성 페이지 클릭 이벤트 구현 및 css 수정
2. 방 생성 페이지 api 연동 구현
3. 방 생성 페이지 라우팅 구현
<br>

## check list

- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
