### PR TITLE
[feat/#59] 게임 결과 페이지 api 연동 ver 2

### DIFF
--- a/src/apis/gameResult.ts
+++ b/src/apis/gameResult.ts
@@ -6,7 +6,7 @@ export const gameResultAPI = async () => {
     //   method:'GET',
     //   path: '/result',
     // });
-    const response = await axios.get('/test');
+    const response = await axios.get('/test'); //msw
     return response;
   } catch (e) {
     alert('연동 에러');

--- a/src/apis/gameResult.ts
+++ b/src/apis/gameResult.ts
@@ -1,0 +1,14 @@
+import { restFetcher } from '@/queryClient';
+import axios from 'axios';
+export const gameResultAPI = async () => {
+  try {
+    // const response = await restFetcher({
+    //   method:'GET',
+    //   path: '/result',
+    // });
+    const response = await axios.get('/test');
+    return response;
+  } catch (e) {
+    alert('연동 에러');
+  }
+};

--- a/src/constants/rank.ts
+++ b/src/constants/rank.ts
@@ -13,6 +13,7 @@ export const USERRANK = [
   '8등급 최현정',
 ];
 
+export const InitialResult = [{ nickname: '', score: 0 }];
 export const bestPlayerName = '서 근 재';
 
 export const crapeTalk =

--- a/src/constants/rank.ts
+++ b/src/constants/rank.ts
@@ -13,7 +13,7 @@ export const USERRANK = [
   '8등급 최현정',
 ];
 
-export const InitialResult = [{ nickname: '', score: 0 }];
+export const InitialResult = { nickname: '', score: 0 };
 export const bestPlayerName = '서 근 재';
 
 export const crapeTalk =

--- a/src/font/defalut.css
+++ b/src/font/defalut.css
@@ -17,6 +17,5 @@
 }
 @font-face {
   font-family: 'KyoboHandwriting2019';
-  src: url('../font/KyoboHandwriting2019/KyoboHandwriting2019.woff')
-
+  src: url('../font/KyoboHandwriting2019/KyoboHandwriting2019.woff');
 }

--- a/src/font/defalut.css
+++ b/src/font/defalut.css
@@ -15,3 +15,8 @@
   font-weight: normal;
   font-style: normal;
 }
+@font-face {
+  font-family: 'KyoboHandwriting2019';
+  src: url('../font/KyoboHandwriting2019/KyoboHandwriting2019.woff')
+
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,9 +5,9 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { worker } from './mocks/worker';
 
-// if (import.meta.env.DEV) {
-//   worker.start();
-// }
+if (import.meta.env.DEV) {
+  worker.start();
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,7 +4,7 @@ const dummy = {
   석차: [
     {
       nickname: '고양양양이',
-      score: 10,
+      score: 1,
     },
     {
       nickname: 'hello',
@@ -28,7 +28,7 @@ const dummy = {
     },
     {
       nickname: '고고',
-      score: 1,
+      score: 10,
     },
     {
       nickname: '핑뭐시기',

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -18,10 +18,7 @@ const dummy = {
       nickname: 'nodes',
       score: 10,
     },
-    {
-      nickname: '고양양양이',
-      score: 5,
-    },
+
     {
       nickname: '노든도나',
       score: 2,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,41 @@
 import { rest } from 'msw';
 
-const dummy = '테스트입니다.';
+const dummy = {
+  석차: [
+    {
+      nickname: '고양양양이',
+      score: 10,
+    },
+    {
+      nickname: 'hello',
+      score: 5,
+    },
+    {
+      nickname: 'hihi',
+      score: 5,
+    },
+    {
+      nickname: 'nodes',
+      score: 10,
+    },
+    {
+      nickname: '고양양양이',
+      score: 5,
+    },
+    {
+      nickname: '노든도나',
+      score: 2,
+    },
+    {
+      nickname: '고고',
+      score: 1,
+    },
+    {
+      nickname: '핑뭐시기',
+      score: 1,
+    },
+  ],
+};
 
 export const handlers = [
   // 테스트 mock api

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -73,7 +73,7 @@ const GameResult = () => {
       <div className="right-items">
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
-          {rankScored !== undefined &&
+          {rankScored &&
             rankScored.map((i) => (
               <RankWrap key={i.nickname}>
                 <RankText rank={i.rank}>{i.rank}등급</RankText>

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -7,7 +7,7 @@ import wrong from '@/assets/wrong.png';
 import { DAY, USERRANK, bestPlayerName, crapeTalk } from '@/constants/rank';
 import { useQuery } from '@tanstack/react-query';
 import axios, { AxiosError } from 'axios';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 const GameResult = () => {
   const naviagte = useNavigate();
@@ -19,21 +19,15 @@ const GameResult = () => {
     nickname: string;
     score: number;
   };
-  type resultRankType = {
-    nickname: string;
-    rank: number;
-  };
-
   const [resultScore, setResultScore] = useState<resultScoreType[]>([
     { nickname: '', score: 0 },
   ]);
-  const [resultRank, setResultRank] = useState<resultRankType[]>([
-    { nickname: '', rank: 0 },
-  ]);
+
   const getServerData = async () => {
     const ResultAPI = await axios.get('/test');
     return ResultAPI;
   };
+
   const { data } = useQuery(['Result'], getServerData, {
     refetchOnWindowFocus: false,
     onSuccess: (data) => {
@@ -43,24 +37,24 @@ const GameResult = () => {
       console.log('onError', e);
     },
   });
-  useEffect(() => {
-    let currentRank = 1;
 
+  const rankScored = useMemo(() => {
+    let currentRank = 1;
     const sortedScore = [...resultScore].sort((a, b) => b.score - a.score);
+
     if (sortedScore[0].score !== undefined) {
       let prevScore = sortedScore[0].score;
 
-      const rankedScore = sortedScore.map((item) => {
+      return sortedScore.map((item) => {
         if (item.score !== prevScore) {
-          currentRank++; // Increment rank when the score changes
+          currentRank++;
         }
-        prevScore = item.score; // Update prevScore for the next iteration
-        return { ...item, rank: currentRank }; // Add rank property to the item
+        prevScore = item.score;
+        return { ...item, rank: currentRank };
       });
-
-      setResultRank(rankedScore);
     }
   }, [resultScore]);
+
   return (
     <GameResultContainer>
       <TheFirstAward>
@@ -75,12 +69,13 @@ const GameResult = () => {
       <div className="right-items">
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
-          {resultRank.map((u, index) => (
-            <>
-              <p>{u.nickname}</p>
-              <p>{u.rank}</p>
-            </>
-          ))}
+          {rankScored !== undefined &&
+            rankScored.map((u, index) => (
+              <>
+                <p>{u.nickname}</p>
+                <p>{u.rank}</p>
+              </>
+            ))}
         </Ranking>
         <Buttons onClick={goToDrwaingRoom}>
           <img src={DrawingRoom} className="drawingRoom-icon" />

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -15,7 +15,11 @@ const GameResult = () => {
   const goToMain = () => naviagte('/');
   const goToDrwaingRoom = () => naviagte('/drawingroom');
 
-  const [resultScore, setResultScore] = useState([{ nickname: '', score: '' }]);
+  type resultScoreType = {
+    nickname: string;
+    score: number;
+  };
+  const [resultScore, setResultScore] = useState<resultScoreType[]>([]);
   const getServerData = async () => {
     const ResultAPI = await axios.get('/test');
     return ResultAPI;
@@ -29,10 +33,6 @@ const GameResult = () => {
       console.log('onError', e);
     },
   });
-
-  if (resultScore) {
-    console.log(resultScore);
-  }
 
   return (
     <GameResultContainer>
@@ -48,12 +48,14 @@ const GameResult = () => {
       <div className="right-items">
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
-          {resultScore.map((u, index) => (
-            <>
-              <p>{u.nickname}</p>
-              <p>{u.score}</p>
-            </>
-          ))}
+          {resultScore
+            .sort((a, b) => b.score - a.score)
+            .map((u, index) => (
+              <>
+                <p>{u.nickname}</p>
+                <p>{u.score}</p>
+              </>
+            ))}
         </Ranking>
         <Buttons onClick={goToDrwaingRoom}>
           <img src={DrawingRoom} className="drawingRoom-icon" />

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -15,7 +15,7 @@ import axios from 'axios';
 import { useState, useMemo } from 'react';
 import { gameResultAPI } from '@/apis/gameResult';
 import { resultScoreType, RankTextProps } from '@/types/gameResult';
-
+import { QueryKeys } from '@/queryClient';
 const GameResult = () => {
   const naviagte = useNavigate();
 
@@ -30,7 +30,7 @@ const GameResult = () => {
     return gameResultAPI();
   };
 
-  const { data } = useQuery(['Result'], getServerData, {
+  const { data } = useQuery([QueryKeys.result], getServerData, {
     refetchOnWindowFocus: false,
     onSuccess: (data) => {
       if (data !== undefined) setResultScore(data.data['석차']);

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -4,10 +4,17 @@ import RankingMemo from '@/assets/RankingMemo.png';
 import DrawingRoom from '@/assets/DrawingRoomIcon.png';
 import { useNavigate } from 'react-router-dom';
 import wrong from '@/assets/wrong.png';
-import { DAY, USERRANK, bestPlayerName, crapeTalk } from '@/constants/rank';
+import {
+  DAY,
+  bestPlayerName,
+  crapeTalk,
+  InitialResult,
+} from '@/constants/rank';
 import { useQuery } from '@tanstack/react-query';
-import axios, { AxiosError } from 'axios';
-import { useState, useEffect, useMemo } from 'react';
+import axios from 'axios';
+import { useState, useMemo } from 'react';
+import { gameResultAPI } from '@/apis/gameResult';
+import { resultScoreType } from '@/types/gameResult';
 
 const GameResult = () => {
   const naviagte = useNavigate();
@@ -15,23 +22,18 @@ const GameResult = () => {
   const goToMain = () => naviagte('/');
   const goToDrwaingRoom = () => naviagte('/drawingroom');
 
-  type resultScoreType = {
-    nickname: string;
-    score: number;
-  };
   const [resultScore, setResultScore] = useState<resultScoreType[]>([
-    { nickname: '', score: 0 },
+    InitialResult,
   ]);
 
-  const getServerData = async () => {
-    const ResultAPI = await axios.get('/test');
-    return ResultAPI;
+  const getServerData = () => {
+    return gameResultAPI();
   };
 
   const { data } = useQuery(['Result'], getServerData, {
     refetchOnWindowFocus: false,
     onSuccess: (data) => {
-      setResultScore(data.data['석차']);
+      if (data !== undefined) setResultScore(data.data['석차']);
     },
     onError: (e) => {
       console.log('onError', e);
@@ -70,10 +72,10 @@ const GameResult = () => {
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
           {rankScored !== undefined &&
-            rankScored.map((u, index) => (
+            rankScored.map((i, index) => (
               <>
-                <p>{u.nickname}</p>
-                <p>{u.rank}</p>
+                <p>{i.nickname}</p>
+                <p>{i.rank}</p>
               </>
             ))}
         </Ranking>

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -253,6 +253,3 @@ const RankText = styled.h3<RankTextProps>`
       color: #bc00fe;
     `}
 `;
-function rankedScore(rankedScore: any) {
-  throw new Error('Function not implemented.');
-}

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import { styled, css } from 'styled-components';
 import Award from '@/assets/Award.png';
 import RankingMemo from '@/assets/RankingMemo.png';
 import DrawingRoom from '@/assets/DrawingRoomIcon.png';
@@ -14,7 +14,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useState, useMemo } from 'react';
 import { gameResultAPI } from '@/apis/gameResult';
-import { resultScoreType } from '@/types/gameResult';
+import { resultScoreType, RankTextProps } from '@/types/gameResult';
 
 const GameResult = () => {
   const naviagte = useNavigate();
@@ -61,9 +61,10 @@ const GameResult = () => {
     <GameResultContainer>
       <TheFirstAward>
         <span className="right-items">발급번호: Techeer-600000호</span>
+
         <span className="center-items">상장</span>
         <span className="center-items">The Best Player of Game</span>
-        <span className="right-items">성명 {bestPlayerName}</span>
+        <span className="right-items">성명</span>
         <span className="center-items">{crapeTalk}</span>
         <span className="center-items">{DAY}</span>
         <span className="center-items">Team D 대표 최현정</span>
@@ -72,11 +73,13 @@ const GameResult = () => {
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
           {rankScored !== undefined &&
-            rankScored.map((i, index) => (
-              <>
-                <p>{i.nickname}</p>
-                <p>{i.rank}</p>
-              </>
+            rankScored.map((i) => (
+              <RankWrap key={i.nickname}>
+                <RankText rank={i.rank}>{i.rank}등급</RankText>
+                <RankText rank={i.rank} nickname>
+                  {i.nickname}
+                </RankText>
+              </RankWrap>
             ))}
         </Ranking>
         <Buttons onClick={goToDrwaingRoom}>
@@ -188,7 +191,6 @@ const Ranking = styled.div`
   background-size: 35vw 60vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
   margin-left: 10rem;
   padding-top: 13rem;
   & > img {
@@ -213,6 +215,38 @@ const Ranking = styled.div`
     opacity: 0.7;
     font-weight: 700;
   }
+`;
+
+const RankWrap = styled.div`
+  display: flex;
+  margin: 0.5rem 7rem 1.1rem 10rem;
+`;
+
+const RankText = styled.h3<RankTextProps>`
+  font-family: 'KyoboHandwriting2019';
+  font-size: 3rem;
+  ${(props) =>
+    props.nickname &&
+    css`
+      margin-left: 2rem;
+    `}
+
+  ${(props) =>
+    props.rank === 1 &&
+    css`
+      color: #e91700;
+    `}
+    ${(props) =>
+    props.rank === 2 &&
+    css`
+      color: #5282ff;
+    `}
+
+  ${(props) =>
+    props.rank === 3 &&
+    css`
+      color: #bc00fe;
+    `}
 `;
 function rankedScore(rankedScore: any) {
   throw new Error('Function not implemented.');

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -7,7 +7,7 @@ import wrong from '@/assets/wrong.png';
 import { DAY, USERRANK, bestPlayerName, crapeTalk } from '@/constants/rank';
 import { useQuery } from '@tanstack/react-query';
 import axios, { AxiosError } from 'axios';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const GameResult = () => {
   const naviagte = useNavigate();
@@ -19,7 +19,17 @@ const GameResult = () => {
     nickname: string;
     score: number;
   };
-  const [resultScore, setResultScore] = useState<resultScoreType[]>([]);
+  type resultRankType = {
+    nickname: string;
+    rank: number;
+  };
+
+  const [resultScore, setResultScore] = useState<resultScoreType[]>([
+    { nickname: '', score: 0 },
+  ]);
+  const [resultRank, setResultRank] = useState<resultRankType[]>([
+    { nickname: '', rank: 0 },
+  ]);
   const getServerData = async () => {
     const ResultAPI = await axios.get('/test');
     return ResultAPI;
@@ -33,7 +43,24 @@ const GameResult = () => {
       console.log('onError', e);
     },
   });
+  useEffect(() => {
+    let currentRank = 1;
 
+    const sortedScore = [...resultScore].sort((a, b) => b.score - a.score);
+    if (sortedScore[0].score !== undefined) {
+      let prevScore = sortedScore[0].score;
+
+      const rankedScore = sortedScore.map((item) => {
+        if (item.score !== prevScore) {
+          currentRank++; // Increment rank when the score changes
+        }
+        prevScore = item.score; // Update prevScore for the next iteration
+        return { ...item, rank: currentRank }; // Add rank property to the item
+      });
+
+      setResultRank(rankedScore);
+    }
+  }, [resultScore]);
   return (
     <GameResultContainer>
       <TheFirstAward>
@@ -48,14 +75,12 @@ const GameResult = () => {
       <div className="right-items">
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
-          {resultScore
-            .sort((a, b) => b.score - a.score)
-            .map((u, index) => (
-              <>
-                <p>{u.nickname}</p>
-                <p>{u.score}</p>
-              </>
-            ))}
+          {resultRank.map((u, index) => (
+            <>
+              <p>{u.nickname}</p>
+              <p>{u.rank}</p>
+            </>
+          ))}
         </Ranking>
         <Buttons onClick={goToDrwaingRoom}>
           <img src={DrawingRoom} className="drawingRoom-icon" />
@@ -192,3 +217,6 @@ const Ranking = styled.div`
     font-weight: 700;
   }
 `;
+function rankedScore(rankedScore: any) {
+  throw new Error('Function not implemented.');
+}

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -56,6 +56,11 @@ const GameResult = () => {
       });
     }
   }, [resultScore]);
+  const winner =
+    rankScored !== undefined &&
+    rankScored
+      .filter((item) => item.rank === 1)
+      .map((item) => item.nickname + ' ');
 
   return (
     <GameResultContainer>
@@ -64,7 +69,7 @@ const GameResult = () => {
 
         <span className="center-items">상장</span>
         <span className="center-items">The Best Player of Game</span>
-        <span className="right-items">성명</span>
+        <span className="right-items">성명 : {winner}</span>
         <span className="center-items">{crapeTalk}</span>
         <span className="center-items">{DAY}</span>
         <span className="center-items">Team D 대표 최현정</span>

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -5,11 +5,34 @@ import DrawingRoom from '@/assets/DrawingRoomIcon.png';
 import { useNavigate } from 'react-router-dom';
 import wrong from '@/assets/wrong.png';
 import { DAY, USERRANK, bestPlayerName, crapeTalk } from '@/constants/rank';
+import { useQuery } from '@tanstack/react-query';
+import axios, { AxiosError } from 'axios';
+import { useState } from 'react';
+
 const GameResult = () => {
   const naviagte = useNavigate();
 
   const goToMain = () => naviagte('/');
   const goToDrwaingRoom = () => naviagte('/drawingroom');
+
+  const [resultScore, setResultScore] = useState([{ nickname: '', score: '' }]);
+  const getServerData = async () => {
+    const ResultAPI = await axios.get('/test');
+    return ResultAPI;
+  };
+  const { data } = useQuery(['Result'], getServerData, {
+    refetchOnWindowFocus: false,
+    onSuccess: (data) => {
+      setResultScore(data.data['석차']);
+    },
+    onError: (e) => {
+      console.log('onError', e);
+    },
+  });
+
+  if (resultScore) {
+    console.log(resultScore);
+  }
 
   return (
     <GameResultContainer>
@@ -25,9 +48,12 @@ const GameResult = () => {
       <div className="right-items">
         <Buttons onClick={goToMain}></Buttons>
         <Ranking>
-          {USERRANK.map((user, index) => {
-            return <span key={index}>{user}</span>;
-          })}
+          {resultScore.map((u, index) => (
+            <>
+              <p>{u.nickname}</p>
+              <p>{u.score}</p>
+            </>
+          ))}
         </Ranking>
         <Buttons onClick={goToDrwaingRoom}>
           <img src={DrawingRoom} className="drawingRoom-icon" />
@@ -98,7 +124,7 @@ const TheFirstAward = styled.div`
     margin-bottom: 0;
   }
   span:nth-child(7) {
-    font-size: 1%.5;
+    font-size: 1.5;
     margin-top: 1rem;
     margin-bottom: 0;
   }

--- a/src/pages/GameResult/index.tsx
+++ b/src/pages/GameResult/index.tsx
@@ -33,7 +33,7 @@ const GameResult = () => {
   const { data } = useQuery([QueryKeys.result], getServerData, {
     refetchOnWindowFocus: false,
     onSuccess: (data) => {
-      if (data !== undefined) setResultScore(data.data['석차']);
+      if (data) setResultScore(data.data['석차']);
     },
     onError: (e) => {
       console.log('onError', e);
@@ -44,23 +44,19 @@ const GameResult = () => {
     let currentRank = 1;
     const sortedScore = [...resultScore].sort((a, b) => b.score - a.score);
 
-    if (sortedScore[0].score !== undefined) {
-      let prevScore = sortedScore[0].score;
+    let prevScore = sortedScore[0].score;
 
-      return sortedScore.map((item) => {
-        if (item.score !== prevScore) {
-          currentRank++;
-        }
-        prevScore = item.score;
-        return { ...item, rank: currentRank };
-      });
-    }
+    return sortedScore.map((item) => {
+      if (item.score !== prevScore) {
+        currentRank++;
+      }
+      prevScore = item.score;
+      return { ...item, rank: currentRank };
+    });
   }, [resultScore]);
-  const winner =
-    rankScored !== undefined &&
-    rankScored
-      .filter((item) => item.rank === 1)
-      .map((item) => item.nickname + ' ');
+  const winner = rankScored
+    .filter((item) => item.rank === 1)
+    .map((item) => item.nickname + ' ');
 
   return (
     <GameResultContainer>

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -65,4 +65,4 @@ export const restFetcher = async ({
   }
 };
 
-export const QueryKeys = {};
+export const QueryKeys = { result: 'result' };

--- a/src/types/gameResult.ts
+++ b/src/types/gameResult.ts
@@ -2,3 +2,8 @@ export type resultScoreType = {
   nickname: string;
   score: number;
 };
+
+export type RankTextProps = {
+  nickname?: boolean;
+  rank?: number;
+};

--- a/src/types/gameResult.ts
+++ b/src/types/gameResult.ts
@@ -1,0 +1,4 @@
+export type resultScoreType = {
+  nickname: string;
+  score: number;
+};


### PR DESCRIPTION
## 추가한 기능 설명

- msw 사용 게임결과 페이지  api 연동
- 리액트쿼리 
- 상장 성명 1등 닉네임으로 변경
- 등급별 닉네임 색깔 변경


## check list

- [✅] issue number를 브랜치 앞에 추가 하였는가?
- [✅] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
